### PR TITLE
Fix limit for "well-defined plasmon excitation"

### DIFF
--- a/sections/section-1.tex
+++ b/sections/section-1.tex
@@ -38,7 +38,7 @@ where $\hat q$ is a unit wavevector due to the lack of wavevector dependence in 
     \sum_{j=x,y,z}\lp\frac{q_j^2}{q^2}\rp\frac{\im\e_{jj}(\omega)}{|\e_{jj}(\omega)|^2}
     \,\,\,.
 \end{equation}
-In the regime of well-defined plasmon excitation, $\Gamma \ll \omega_{j,0}$ for all $j=x,y,z$, the plasmon dispersion roughly follows from zeros in the real part of the {\it longitudinal} dielectric function,
+In the regime of well-defined plasmon excitation, $\Gamma \ll \omega$ for $\omega$ near the plasma frequency, the plasmon dispersion roughly follows from zeros in the real part of the {\it longitudinal} dielectric function,
 \begin{equation}
     \e_L(\hat q,\omega) :=\hat q\cdot \e\cdot\hat q\,\,\,,
 \end{equation}


### PR DESCRIPTION
## Changes
- Fixed incorrect reference to `w_j` in limit of well-defined plasmons